### PR TITLE
[feat#35] 내부 배포 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 *.iml
 .idea/*
 .kotlin
+*.apk
 
 # macOs
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ xcuserdata
 **/xcshareddata/WorkspaceSettings.xcsettings
 
 # IntelliJ
-*.iml
 .idea/
 misc.xml
 deploymentTargetDropDown.xml

--- a/composeApp/release/output-metadata.json
+++ b/composeApp/release/output-metadata.json
@@ -1,0 +1,20 @@
+{
+  "version": 3,
+  "artifactType": {
+    "type": "APK",
+    "kind": "Directory"
+  },
+  "applicationId": "team.aliens.dms.kmp",
+  "variantName": "release",
+  "elements": [
+    {
+      "type": "SINGLE",
+      "filters": [],
+      "attributes": [],
+      "versionCode": 1,
+      "versionName": "1.0.0",
+      "outputFile": "composeApp-release.apk"
+    }
+  ],
+  "elementType": "File"
+}

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,3 +1,3 @@
 TEAM_ID=
-BUNDLE_ID=team.aliens.dms.kmp.DmsKmp
+BUNDLE_ID=team.aliens.dms.kmp.Dms-Kmp
 APP_NAME=DmsKmp

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		80B99D812C9FA5EA00669921 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 80B99D802C9FA5EA00669921 /* FirebaseAnalytics */; };
 		80B99D832C9FA62100669921 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 80B99D822C9FA62100669921 /* FirebaseCrashlytics */; };
-		80B99D852C9FA6D200669921 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 80B99D842C9FA6D200669921 /* GoogleService-Info.plist */; };
+		80B99D872CA047AA00669921 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 80B99D862CA047AA00669921 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,7 +23,7 @@
 		7555FF7B242A565900829871 /* DmsKmp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DmsKmp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		80B99D842C9FA6D200669921 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		80B99D862CA047AA00669921 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -81,7 +81,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				2152FB032600AC8F00CF470E /* iOSApp.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
-				80B99D842C9FA6D200669921 /* GoogleService-Info.plist */,
+				80B99D862CA047AA00669921 /* GoogleService-Info.plist */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -163,7 +163,7 @@
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
-				80B99D852C9FA6D200669921 /* GoogleService-Info.plist in Resources */,
+				80B99D872CA047AA00669921 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -330,7 +330,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				DEVELOPMENT_TEAM = Z25H7B85Z8;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -357,7 +357,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"iosApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				DEVELOPMENT_TEAM = Z25H7B85Z8;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -4,7 +4,7 @@ import ComposeApp
 
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        MainViewControllerKt.MainViewController()
+        MainViewControllerKt.mainViewController()
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}

--- a/iosApp/iosApp/GoogleService-Info.plist
+++ b/iosApp/iosApp/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyCCq5ajTnVT1MygBe4tBwIxwwdSkEPhsRI</string>
+	<key>GCM_SENDER_ID</key>
+	<string>186953013707</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>team.aliens.dms.kmp.Dms-Kmp</string>
+	<key>PROJECT_ID</key>
+	<string>dms-kmp</string>
+	<key>STORAGE_BUCKET</key>
+	<string>dms-kmp.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:186953013707:ios:091c915aea97330626fe4e</string>
+</dict>
+</plist>

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import ComposeApp
+import FirebaseCore
 
 @main
 struct iOSApp: App {
@@ -6,7 +8,6 @@ struct iOSApp: App {
     init() {
         KoinKt.doInitKoin()
         FirebaseApp.configure()
-        FirebaseApp.crashlytics.setCrashlyticsCollectionEnabled(true)
     }
     
     var body: some Scene {


### PR DESCRIPTION
## 개요
>파이어베이스를 사용해서 내부 배포를 세팅 하였습니다.

## 작업사항
- 파이어베이스 연동
- iOS Developer 연결

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- Android 애플리케이션의 빌드 메타데이터를 포함하는 `output-metadata.json` 파일 추가.
	- iOS 애플리케이션에 Google 서비스 통합을 위한 `GoogleService-Info.plist` 파일 추가.
  
- **변경 사항**
	- iOS 애플리케이션의 `BUNDLE_ID` 업데이트.
	- `GoogleService-Info.plist` 파일에 대한 참조 업데이트.
	- `makeUIViewController` 메서드에서 호출 변경. 

- **기타**
	- `.gitignore` 파일 수정: APK 파일 무시 추가 및 IntelliJ 모듈 파일 무시 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->