### PR TITLE
[feat #84] :: 신청 화면 퍼블리싱

### DIFF
--- a/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/appbar/DmsTopAppBar.kt
+++ b/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/appbar/DmsTopAppBar.kt
@@ -90,16 +90,16 @@ fun DmsLargeTopAppBar(
             .fillMaxWidth()
             .background(DmsTheme.colors.background),
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    horizontal = 16.dp,
-                    vertical = 12.dp,
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            onBackPressed?.let {
+        onBackPressed?.let {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 16.dp,
+                        vertical = 12.dp,
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
                 DmsIconButton(
                     resource = DmsIcon.ArrowBack,
                     tint = DmsTheme.colors.surfaceContainerLow,

--- a/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/button/DmsIconButton.kt
+++ b/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/button/DmsIconButton.kt
@@ -15,12 +15,13 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
 
 @Composable
 fun DmsIconButton(
     modifier: Modifier = Modifier,
     resource: DrawableResource,
-    tint: Color,
+    tint: Color = DmsTheme.colors.surfaceContainerLow,
     enabled: Boolean = true,
     size: Dp = 24.dp,
     contentDescription: String? = null,

--- a/feature/application/build.gradle.kts
+++ b/feature/application/build.gradle.kts
@@ -42,6 +42,10 @@ kotlin {
             implementation(compose.material3)
             implementation(compose.ui)
             implementation(libs.navigation.compose)
+            implementation(compose.components.resources)
+
+            implementation(projects.core.designSystem)
+            implementation(projects.core.common)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/TermsScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/TermsScreen.kt
@@ -111,16 +111,12 @@ private fun AllAgreeButton(
     onAllAgreeButtonClick: (Boolean) -> Unit,
 ) {
     var isCheck by remember { mutableStateOf(buttonEnabled) }
-    val background = if (isCheck) {
-        DmsTheme.colors.onSecondary
+    val (background, contentColor) = if (isCheck) {
+        DmsTheme.colors.onSecondary to DmsTheme.colors.surfaceContainerHighest
     } else {
-        DmsTheme.colors.onBackground
+        DmsTheme.colors.onBackground to DmsTheme.colors.onSurface
     }
-    val contentColor = if (isCheck) {
-        DmsTheme.colors.surfaceContainerHighest
-    } else {
-        DmsTheme.colors.onSurface
-    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
## 개요
>

Android|iOS|Desktop
--|--|--

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `DmsLargeTopAppBar`의 백 버튼 레이아웃 개선: `onBackPressed` 콜백에 따라 백 버튼이 항상 표시되도록 변경.
	- `DmsIconButton`의 기본 색상 설정: `tint` 파라미터에 기본값 추가.
	- `TermsScreen`의 `AllAgreeButton` 색상 로직 간소화.

- **버그 수정**
	- 없음.

- **문서화**
	- 없음.

- **리팩토링**
	- 색상 할당 로직을 간소화하여 가독성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->