### PR TITLE
[refactor #90] :: 로그인 회원가입 코드 제거

### DIFF
--- a/feature/signin/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signin/ui/SignInScreen.kt
+++ b/feature/signin/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signin/ui/SignInScreen.kt
@@ -44,6 +44,5 @@ fun SignInScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signin/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signin/ui/SignInScreen.kt
+++ b/feature/signin/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signin/ui/SignInScreen.kt
@@ -1,32 +1,14 @@
 package team.aliens.dms.kmp.feature.signin.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
-import team.aliens.dms.kmp.core.designsystem.button.DmsOutlineButton
-import team.aliens.dms.kmp.core.designsystem.foundation.DmsSymbol
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
-import team.aliens.dms.kmp.core.designsystem.text.DmsText
-import team.aliens.dms.kmp.core.designsystem.textfield.DmsTextField
 import team.aliens.dms.kmp.feature.signin.viewmodel.SignInState
 import team.aliens.dms.kmp.feature.signin.viewmodel.SignInViewModel
 
@@ -62,108 +44,6 @@ fun SignInScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsSymbol(
-            modifier = Modifier
-                .topPadding(36.dp)
-                .horizontalPadding(),
-        )
-        UserInformationInputs(
-            modifier = Modifier.topPadding(PaddingDefaults.ExtraLarge),
-            accountId = state.accountId,
-            onAccountIdChange = onAccountIdChange,
-            password = state.password,
-            onPasswordChange = onPasswordChange,
-        )
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(28.dp)
-                .horizontalPadding(),
-            text = "로그인",
-            enabled = state.buttonEnabled,
-            onClick = navigateToMain,
-        )
-        UnauthorizedActions(
-            onFindId = { },
-            onFindPassword = { },
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        DmsOutlineButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(16.dp),
-            text = "회원가입 하기",
-            onClick = navigateToSignUp,
-        )
-    }
-}
 
-@Composable
-private fun UserInformationInputs(
-    modifier: Modifier = Modifier,
-    accountId: String,
-    onAccountIdChange: (String) -> Unit,
-    password: String,
-    onPasswordChange: (String) -> Unit,
-) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .horizontalPadding(),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        DmsTextField(
-            value = accountId,
-            onValueChange = onAccountIdChange,
-            hint = "아이디를 입력해주세요",
-            label = "아이디",
-            showClearIcon = true,
-        )
-        DmsTextField(
-            value = password,
-            onValueChange = onPasswordChange,
-            hint = "비밀번호를 입력해주세요",
-            label = "비밀번호",
-            keyboardType = KeyboardType.Password,
-            showVisibleIcon = true,
-        )
-    }
-}
-
-@Composable
-private fun UnauthorizedActions(
-    modifier: Modifier = Modifier,
-    onFindId: () -> Unit,
-    onFindPassword: () -> Unit,
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .topPadding(PaddingDefaults.ExtraLarge)
-            .horizontalPadding(),
-        horizontalArrangement = Arrangement.spacedBy(
-            space = PaddingDefaults.Medium,
-            alignment = Alignment.CenterHorizontally,
-        ),
-    ) {
-        DmsText(
-            modifier = Modifier.clickable(
-                onClick = onFindId,
-            ),
-            text = "아이디 찾기",
-            style = DmsTypography.Body1Medium,
-        )
-        DmsText(
-            text = "|",
-            style = DmsTypography.Body1Medium,
-        )
-        DmsText(
-            modifier = Modifier.clickable(
-                onClick = onFindPassword,
-            ),
-            text = "비밀번호 찾기",
-            style = DmsTypography.Body1Medium,
-        )
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailScreen.kt
@@ -54,6 +54,5 @@ private fun EnterEmailScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailScreen.kt
@@ -2,23 +2,14 @@ package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.textfield.DmsTextField
 import team.aliens.dms.kmp.feature.signup.model.SignUpData
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterEmailSideEffect
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterEmailState
@@ -63,28 +54,6 @@ private fun EnterEmailScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = "이메일을 입력해주세요",
-            description = "학교 이메일을 입력해주세요.",
-        )
-        DmsTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(PaddingDefaults.ExtraLarge)
-                .horizontalPadding(),
-            value = state.email,
-            onValueChange = onEmailChange,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = onNextClick,
-            enabled = state.buttonEnabled,
-        )
+
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailVerificationCodeScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailVerificationCodeScreen.kt
@@ -54,6 +54,5 @@ private fun EnterEmailVerificationCodeScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailVerificationCodeScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterEmailVerificationCodeScreen.kt
@@ -1,36 +1,15 @@
 package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
-import team.aliens.dms.kmp.core.designsystem.foundation.DmsIcon
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
-import team.aliens.dms.kmp.core.designsystem.numberfield.DmsNumberField
-import team.aliens.dms.kmp.core.designsystem.text.DmsText
-import team.aliens.dms.kmp.core.designsystem.timer.DmsTimer
 import team.aliens.dms.kmp.feature.signup.model.SignUpData
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterEmailVerificationCodeSideEffect
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterEmailVerificationCodeState
@@ -75,66 +54,6 @@ private fun EnterEmailVerificationCodeScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = "인증코드를 입력해주세요",
-            description = "입력하신 이메일 주소로 인증코드가 전송되었어요.",
-        )
-        VerificationCode(
-            emailVerificationCode = state.emailVerificationCode,
-            onEmailVerificationCodeChange = onEmailVerificationCodeChange,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = onNextClick,
-            enabled = state.buttonEnabled,
-        )
-    }
-}
 
-@Composable
-fun VerificationCode(
-    modifier: Modifier = Modifier,
-    emailVerificationCode: String,
-    onEmailVerificationCodeChange: (String) -> Unit,
-) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .topPadding(PaddingDefaults.ExtraLarge)
-            .horizontalPadding(),
-    ) {
-        DmsTimer()
-        Spacer(modifier = Modifier.height(PaddingDefaults.Large))
-        DmsNumberField(
-            modifier = Modifier.fillMaxWidth(),
-            value = emailVerificationCode,
-            onValueChange = onEmailVerificationCodeChange,
-            totalLength = 6,
-        )
-        Spacer(modifier = Modifier.height(PaddingDefaults.ExtraLarge))
-        Row(
-            modifier = Modifier.clickable(
-                onClick = { },
-            ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Icon(
-                painter = painterResource(DmsIcon.Refresh),
-                contentDescription = "refresh",
-                tint = DmsTheme.colors.secondary,
-            )
-            DmsText(
-                text = "인증문자 재발송",
-                style = DmsTypography.Body1Medium,
-                color = DmsTheme.colors.secondary,
-            )
-        }
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationCodeScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationCodeScreen.kt
@@ -2,23 +2,14 @@ package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.numberfield.DmsNumberField
 import team.aliens.dms.kmp.feature.signup.model.SignUpData
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterSchoolVerificationCodeSideEffect
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterSchoolVerificationCodeState
@@ -64,29 +55,6 @@ private fun EnterSchoolVerificationCodeScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = "인증코드를 입력해주세요",
-            description = "학교 인증코드를 입력해주세요.",
-        )
-        DmsNumberField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(PaddingDefaults.ExtraLarge)
-                .horizontalPadding(),
-            value = state.verificationCode,
-            onValueChange = onVerificationCodeChange,
-            totalLength = VERIFICATION_CODE_LENGTH,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = onNextClick,
-            enabled = state.buttonEnabled,
-        )
+
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationCodeScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationCodeScreen.kt
@@ -55,6 +55,5 @@ private fun EnterSchoolVerificationCodeScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationQuestionScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationQuestionScreen.kt
@@ -54,6 +54,5 @@ private fun EnterSchoolVerificationQuestionScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationQuestionScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/EnterSchoolVerificationQuestionScreen.kt
@@ -2,23 +2,14 @@ package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.textfield.DmsTextField
 import team.aliens.dms.kmp.feature.signup.model.SignUpData
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterSchoolVerificationQuestionSideEffect
 import team.aliens.dms.kmp.feature.signup.viewmodel.EnterSchoolVerificationQuestionState
@@ -63,28 +54,6 @@ private fun EnterSchoolVerificationQuestionScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = state.schoolVerificationQuestion,
-            description = "재학생이 맞는지 확인하는 단계입니다.",
-        )
-        DmsTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(PaddingDefaults.ExtraLarge)
-                .horizontalPadding(),
-            value = state.schoolVerificationAnswer,
-            onValueChange = onVerificationAnswerChange,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = onNextClick,
-            enabled = state.buttonEnabled,
-        )
+
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetIdScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetIdScreen.kt
@@ -1,28 +1,15 @@
 package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.textfield.DmsTextField
 import team.aliens.dms.kmp.feature.signup.model.SignUpData
 import team.aliens.dms.kmp.feature.signup.viewmodel.SetIdSideEffect
 import team.aliens.dms.kmp.feature.signup.viewmodel.SetIdState
@@ -78,48 +65,6 @@ private fun SetIdScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = "아이디를 입력해주세요",
-            description = "DMS에서 사용 할 아이디를 입력해주세요.",
-        )
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(PaddingDefaults.ExtraLarge)
-                .horizontalPadding(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            DmsTextField(
-                modifier = Modifier.weight(1f),
-                value = state.grade,
-                onValueChange = onGradeChange,
-                label = "학년",
-                keyboardType = KeyboardType.Number,
-            )
-            DmsTextField(
-                modifier = Modifier.weight(1f),
-                value = state.classroom,
-                onValueChange = onClassRoomChange,
-                label = "반",
-                keyboardType = KeyboardType.Number,
-            )
-            DmsTextField(
-                modifier = Modifier.weight(1f),
-                value = state.number,
-                onValueChange = onNumberChange,
-                label = "번호",
-                keyboardType = KeyboardType.Number,
-            )
-        }
-        Spacer(modifier = Modifier.weight(1f))
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = onNextClick,
-        )
+
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetIdScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetIdScreen.kt
@@ -65,6 +65,5 @@ private fun SetIdScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetPasswordScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetPasswordScreen.kt
@@ -58,6 +58,5 @@ private fun SetPasswordScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetPasswordScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/SetPasswordScreen.kt
@@ -2,25 +2,14 @@ package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.textfield.DmsTextField
 import team.aliens.dms.kmp.feature.signup.model.SignUpData
 import team.aliens.dms.kmp.feature.signup.viewmodel.SetPasswordSideEffect
 import team.aliens.dms.kmp.feature.signup.viewmodel.SetPasswordState
@@ -69,48 +58,6 @@ private fun SetPasswordScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = "비밀번호를 입력해주세요",
-            description = "비밀번호는 영문, 숫자, 기호를 포함한 8~20자로 입력해주세요.",
-        )
-        DmsTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(PaddingDefaults.ExtraLarge)
-                .horizontalPadding(),
-            value = state.password,
-            onValueChange = onPasswordChange,
-            hint = "비밀번호를 입력해주세요",
-            label = "비밀번호 입력",
-            showVisibleIcon = true,
-            isError = state.showPasswordDescription,
-            errorDescription = "영문, 숫자, 기호를 포함한 8~20자로 설정해주세요.",
-            keyboardType = KeyboardType.Password,
-        )
-        DmsTextField(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(36.dp)
-                .horizontalPadding(),
-            value = state.passwordCheck,
-            onValueChange = onCheckPasswordChange,
-            hint = "비밀번호를 다시 입력해주세요",
-            label = "비밀번호 확인",
-            showVisibleIcon = true,
-            isError = state.showCheckPasswordDescription,
-            errorDescription = "비밀번호가 일치하지 않습니다. 다시 입력해주세요.",
-            keyboardType = KeyboardType.Password,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = onNextClick,
-            enabled = state.buttonEnabled,
-        )
+
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/TermsScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/TermsScreen.kt
@@ -1,39 +1,15 @@
 package team.aliens.dms.kmp.feature.signup.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
-import team.aliens.dms.kmp.core.common.ui.PaddingDefaults
-import team.aliens.dms.kmp.core.common.ui.bottomPadding
-import team.aliens.dms.kmp.core.common.ui.horizontalPadding
-import team.aliens.dms.kmp.core.common.ui.topPadding
-import team.aliens.dms.kmp.core.designsystem.appbar.DmsLargeTopAppBar
-import team.aliens.dms.kmp.core.designsystem.button.DmsButton
-import team.aliens.dms.kmp.core.designsystem.foundation.DmsIcon
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
-import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
-import team.aliens.dms.kmp.core.designsystem.text.DmsText
-import team.aliens.dms.kmp.core.designsystem.webview.DmsWebView
 import team.aliens.dms.kmp.feature.signup.viewmodel.TermsState
 import team.aliens.dms.kmp.feature.signup.viewmodel.TermsViewModel
 
@@ -75,78 +51,6 @@ private fun TermsScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-        DmsLargeTopAppBar(
-            onBackPressed = onBackPressed,
-            title = "개인정보처리방침 안내",
-            description = "개인정보처리방침을 확인해주세요.",
-        )
-        AllAgreeButton(
-            buttonEnabled = state.buttonEnabled,
-            onAllAgreeButtonClick = onAllAgreeButtonClick,
-        )
-        DmsWebView(
-            modifier = Modifier
-                .weight(1f)
-                .topPadding(PaddingDefaults.Medium)
-                .horizontalPadding()
-                .clip(RoundedCornerShape(8.dp)),
-            url = "$termsUrl/policy/privacy?theme=$theme",
-        )
-        DmsButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .topPadding(PaddingDefaults.ExtraLarge)
-                .horizontalPadding()
-                .bottomPadding(),
-            text = "다음",
-            onClick = navigateToSignIn,
-            enabled = state.buttonEnabled,
-        )
-    }
-}
 
-@Composable
-private fun AllAgreeButton(
-    buttonEnabled: Boolean,
-    onAllAgreeButtonClick: (Boolean) -> Unit,
-) {
-    var isCheck by remember { mutableStateOf(buttonEnabled) }
-    val (background, contentColor) = if (isCheck) {
-        DmsTheme.colors.onSecondary to DmsTheme.colors.surfaceContainerHighest
-    } else {
-        DmsTheme.colors.onBackground to DmsTheme.colors.onSurface
-    }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .topPadding(PaddingDefaults.ExtraLarge)
-            .horizontalPadding()
-            .background(
-                color = background,
-                shape = RoundedCornerShape(8.dp),
-            )
-            .clickable(
-                interactionSource = null,
-                indication = null,
-                onClick = {
-                    isCheck = !isCheck
-                    onAllAgreeButtonClick(isCheck)
-                },
-            )
-            .padding(PaddingDefaults.Large),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Icon(
-            painter = painterResource(DmsIcon.Check),
-            contentDescription = "check",
-            tint = contentColor,
-        )
-        DmsText(
-            text = "전체 동의",
-            style = DmsTypography.SubtitleSemiBold,
-            color = contentColor,
-        )
     }
 }

--- a/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/TermsScreen.kt
+++ b/feature/signup/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signup/ui/TermsScreen.kt
@@ -51,6 +51,5 @@ private fun TermsScreen(
             .fillMaxSize()
             .background(DmsTheme.colors.background),
     ) {
-
     }
 }


### PR DESCRIPTION
## 개요
>로그인 및 회원가입 화면 코드를 제거하였습니다.

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI 변경**
	- 로그인, 회원가입 화면의 주요 UI 컴포넌트 제거
	- 이메일 인증, 학교 인증, 비밀번호 설정 등의 화면 구조 단순화
	- 이용약관 화면의 UI 요소 대폭 축소

- **기능 변경**
	- 사용자 입력 필드 및 탐색 버튼 제거
	- 화면 간 상호작용 흐름 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->