### PR TITLE
[refactor] :: iOS 개발 환경 분리

### DIFF
--- a/core/network/src/iosMain/kotlin/team/aliens/dms/kmp/core/network/PlatformConfig.ios.kt
+++ b/core/network/src/iosMain/kotlin/team/aliens/dms/kmp/core/network/PlatformConfig.ios.kt
@@ -7,7 +7,7 @@ import team.aliens.dms.kmp.core.network.exception.CannotFindIOSWebViewUrlExcepti
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual object PlatformConfig {
     actual val baseUrl: String =
-        (NSBundle.mainBundle.objectForInfoDictionaryKey("DEV_BASE_URL") as? String)
+        (NSBundle.mainBundle.objectForInfoDictionaryKey("BASE_URL") as? String)
             ?: throw CannotFindIOSBaseurlException()
 
     actual val webViewUrl: String =

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 		7555FFA6242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 80AF93EF2CB12667003ABC55 /* Configuration */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Dev.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -358,7 +358,7 @@
 		7555FFA7242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReferenceAnchor = 80AF93EF2CB12667003ABC55 /* Configuration */;
-			baseConfigurationReferenceRelativePath = Config.xcconfig;
+			baseConfigurationReferenceRelativePath = Release.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BASE_URL</key>
+	<string>$(BASE_URL)</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>
@@ -20,12 +22,8 @@
 	<string>0.0.2</string>
 	<key>CFBundleVersion</key>
 	<string>3</string>
-	<key>DEV_BASE_URL</key>
-	<string>$(DEV_BASE_URL)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>PROD_BASE_URL</key>
-	<string>$(PROD_BASE_URL)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## 개요
>iOS 개발 환경 분리
- Dev, Release xcconfig 파일 추가 필요

Android|iOS|Desktop
--|--|--

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* iOS 앱의 기본 URL 설정 구조를 통합했습니다.
* 빌드 설정 파일을 재구성했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->