### PR TITLE
 [refactor #151] 알림 공지 화면 레이아웃 크기 제약 수정

### DIFF
--- a/core/network/src/commonMain/kotlin/team/aliens/dms/kmp/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/team/aliens/dms/kmp/core/network/di/NetworkModule.kt
@@ -65,6 +65,7 @@ val networkModule = module {
                         isLenient = true
                         ignoreUnknownKeys = true
                         encodeDefaults = true
+                        explicitNulls = false
                     },
                 )
             }

--- a/feature/notification/src/commonMain/kotlin/team/aliens/dms/kmp/feature/notification/ui/NotificationScreen.kt
+++ b/feature/notification/src/commonMain/kotlin/team/aliens/dms/kmp/feature/notification/ui/NotificationScreen.kt
@@ -185,7 +185,7 @@ private fun NoticeItems(
     onNotificationDetailClick: (String, String) -> Unit,
 ) {
     LazyColumn(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxSize(),
     ) {
         items(
             items = notices,


### PR DESCRIPTION
## 개요
> 알림 공지 화면 레이아웃 크기 제약 수정

Android|iOS|Desktop
--|--|--

## 작업사항
- 레이아웃 크기 제약 수정
- 서버 데이터 필드 누락 시 널로 채워지도록 설정

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 알림 목록이 화면 크기에 맞게 표시되도록 레이아웃 개선

* **기술 개선**
  * 네트워크 데이터 직렬화 설정 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->