### PR TITLE
[refactor #177] 로그인/아이디 찾기 문구 수정

### DIFF
--- a/feature/find-id/src/commonMain/kotlin/team/aliens/dms/kmp/feature/findid/FindIdScreen.kt
+++ b/feature/find-id/src/commonMain/kotlin/team/aliens/dms/kmp/feature/findid/FindIdScreen.kt
@@ -56,7 +56,7 @@ internal fun FindIdScreen(
     if (state.isShowIdDialog) {
         DmsAlertDialog(
             title = "회원님의 아이디가 발송되었습니다!",
-            description = "회원님의 아이디는 ${state.email.email}에 발송되었습니다.",
+            description = "회원님의 아이디가 ${state.email.email}로 발송되었습니다.",
             onClose = viewModel::hideDialog,
         )
     }

--- a/feature/find-id/src/commonMain/kotlin/team/aliens/dms/kmp/feature/findid/FindIdScreen.kt
+++ b/feature/find-id/src/commonMain/kotlin/team/aliens/dms/kmp/feature/findid/FindIdScreen.kt
@@ -55,8 +55,8 @@ internal fun FindIdScreen(
 
     if (state.isShowIdDialog) {
         DmsAlertDialog(
-            title = "회원님의 아이디를 찾았습니다!",
-            description = "회원님의 아이디는 ${state.email.email}입니다.",
+            title = "회원님의 아이디가 발송되었습니다!",
+            description = "회원님의 아이디는 ${state.email.email}에 발송되었습니다.",
             onClose = viewModel::hideDialog,
         )
     }

--- a/feature/signin/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signin/ui/SignInScreen.kt
+++ b/feature/signin/src/commonMain/kotlin/team/aliens/dms/kmp/feature/signin/ui/SignInScreen.kt
@@ -151,7 +151,7 @@ private fun UserInformationInputs(
                 .padding(top = 32.dp),
             label = "비밀번호",
             value = password,
-            hint = "비빌번호 입력",
+            hint = "비밀번호 입력",
             onValueChange = onPasswordChange,
             showVisibleIcon = true,
         )


### PR DESCRIPTION
## 개요
>로그인 화면의 비밀번호 오타와 아이디 찾기 안내 문구를 수정합니다.

Android|iOS|Desktop
--|--|--

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 로그인 화면의 비밀번호 입력 필드 안내 텍스트 오타 수정 — 안내 문구를 올바른 표현("비밀번호 입력")으로 정정했습니다.
  * 아이디 찾기 완료 다이얼로그 문구 업데이트 — 아이디가 사용자 이메일로 발송되었음을 명확히 안내하도록 메시지를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->