### PR TITLE
[bug #186] ::  새벽 자습 신청 기능 개편

### DIFF
--- a/composeApp/src/commonMain/kotlin/team/aliens/dms/kmp/navigation/main/MainNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/team/aliens/dms/kmp/navigation/main/MainNavigation.kt
@@ -11,6 +11,7 @@ import team.aliens.dms.kmp.feature.editpassword.navigation.checkPassword
 import team.aliens.dms.kmp.feature.editpassword.navigation.editPassword
 import team.aliens.dms.kmp.feature.editpassword.navigation.navigateToCheckPassword
 import team.aliens.dms.kmp.feature.editpassword.navigation.navigateToEditPassword
+import team.aliens.dms.kmp.feature.latestudy.navigation.LATE_STUDY_STATUS_REFRESH_KEY
 import team.aliens.dms.kmp.feature.latestudy.navigation.lateStudy
 import team.aliens.dms.kmp.feature.latestudy.navigation.navigateToLateStudy
 import team.aliens.dms.kmp.feature.meal.navigation.meal
@@ -76,6 +77,11 @@ internal fun NavGraphBuilder.mainGraph(
         remainApplication(onNavigateBack = appState.navController::navigateUp)
         lateStudy(
             onNavigateBack = appState.navController::navigateUp,
+            onSubmitted = {
+                appState.navController.previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.set(LATE_STUDY_STATUS_REFRESH_KEY, true)
+            },
             onShowSnackBar = appState::showSnackBar,
         )
         vote(

--- a/composeApp/src/commonMain/kotlin/team/aliens/dms/kmp/root/RootNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/team/aliens/dms/kmp/root/RootNavigation.kt
@@ -1,11 +1,14 @@
 package team.aliens.dms.kmp.root
 
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 import team.aliens.dms.kmp.core.designsystem.snackbar.DmsSnackBarType
 import team.aliens.dms.kmp.core.model.type.PointType
 import team.aliens.dms.kmp.core.model.votes.VoteModel
+import team.aliens.dms.kmp.feature.latestudy.navigation.LATE_STUDY_STATUS_REFRESH_KEY
 
 @Serializable
 data object RootRoute
@@ -23,8 +26,16 @@ fun NavGraphBuilder.root(
     onNavigateSetting: () -> Unit,
     onShowSnackBar: (DmsSnackBarType, String) -> Unit,
 ) {
-    composable<RootRoute> {
+    composable<RootRoute> { backStackEntry ->
+        val shouldRefreshLateStudyStatus by backStackEntry.savedStateHandle
+            .getStateFlow(LATE_STUDY_STATUS_REFRESH_KEY, false)
+            .collectAsState()
+
         Root(
+            shouldRefreshLateStudyStatus = shouldRefreshLateStudyStatus,
+            onLateStudyStatusRefreshed = {
+                backStackEntry.savedStateHandle[LATE_STUDY_STATUS_REFRESH_KEY] = false
+            },
             onNavigateRemainApplication = onNavigateRemainApplication,
             onNavigateOutingApplication = onNavigateOutingApplication,
             onNavigateLateStudyApplication = onNavigateLateStudyApplication,

--- a/composeApp/src/commonMain/kotlin/team/aliens/dms/kmp/root/RootScreen.kt
+++ b/composeApp/src/commonMain/kotlin/team/aliens/dms/kmp/root/RootScreen.kt
@@ -22,6 +22,8 @@ import team.aliens.dms.kmp.ui.BottomNavigationBar
 
 @Composable
 internal fun Root(
+    shouldRefreshLateStudyStatus: Boolean,
+    onLateStudyStatusRefreshed: () -> Unit,
     onNavigateRemainApplication: () -> Unit,
     onNavigateOutingApplication: () -> Unit,
     onNavigateLateStudyApplication: () -> Unit,
@@ -35,6 +37,8 @@ internal fun Root(
     onShowSnackBar: (DmsSnackBarType, String) -> Unit,
 ) {
     RootScreen(
+        shouldRefreshLateStudyStatus = shouldRefreshLateStudyStatus,
+        onLateStudyStatusRefreshed = onLateStudyStatusRefreshed,
         onNavigateRemainApplication = onNavigateRemainApplication,
         onNavigateOutingApplication = onNavigateOutingApplication,
         onNavigateLateStudyApplication = onNavigateLateStudyApplication,
@@ -51,6 +55,8 @@ internal fun Root(
 
 @Composable
 private fun RootScreen(
+    shouldRefreshLateStudyStatus: Boolean,
+    onLateStudyStatusRefreshed: () -> Unit,
     onNavigateRemainApplication: () -> Unit,
     onNavigateOutingApplication: () -> Unit,
     onNavigateLateStudyApplication: () -> Unit,
@@ -85,6 +91,8 @@ private fun RootScreen(
                 onShowSnackBar = onShowSnackBar,
             )
             application(
+                shouldRefreshLateStudyStatus = shouldRefreshLateStudyStatus,
+                onLateStudyStatusRefreshed = onLateStudyStatusRefreshed,
                 onNavigateRemainApplication = onNavigateRemainApplication,
                 onNavigateOutingApplication = onNavigateOutingApplication,
                 onNavigateLateStudyApplication = onNavigateLateStudyApplication,

--- a/core/common/src/commonMain/kotlin/team/aliens/dms/kmp/core/common/exception/network/BadRequestException.kt
+++ b/core/common/src/commonMain/kotlin/team/aliens/dms/kmp/core/common/exception/network/BadRequestException.kt
@@ -1,6 +1,8 @@
 package team.aliens.dms.kmp.core.common.exception.network
 
-class BadRequestException : NetworkException(
+class BadRequestException(
+    val errorCode: String? = null,
+) : NetworkException(
     code = 400,
     message = "Bad request",
 )

--- a/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/card/DmsApplicationCard.kt
+++ b/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/card/DmsApplicationCard.kt
@@ -29,6 +29,12 @@ import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
 import team.aliens.dms.kmp.core.designsystem.text.DmsText
 import team.aliens.dms.kmp.core.designsystem.util.clickable
 
+enum class ApplicationBadgeStatus {
+    APPROVED,
+    REJECTED,
+    PENDING,
+}
+
 @Composable
 fun DmsApplicationCard(
     modifier: Modifier = Modifier,
@@ -36,6 +42,7 @@ fun DmsApplicationCard(
     description: String? = null,
     period: String? = null,
     appliedTitle: String? = null,
+    appliedBadgeStatus: ApplicationBadgeStatus? = null,
     iconRes: DrawableResource,
     isSelected: Boolean = false,
     onClick: () -> Unit,
@@ -80,6 +87,7 @@ fun DmsApplicationCard(
                 AppliedTitleText(
                     modifier = Modifier.endPadding(16.dp),
                     appliedTitle = appliedTitle,
+                    badgeStatus = appliedBadgeStatus,
                 )
             }
             Icon(
@@ -107,7 +115,10 @@ fun DmsApplicationCard(
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 if (!appliedTitle.isNullOrEmpty()) {
-                    AppliedTitleText(appliedTitle = appliedTitle)
+                    AppliedTitleText(
+                        appliedTitle = appliedTitle,
+                        badgeStatus = appliedBadgeStatus,
+                    )
                 }
             }
         }
@@ -118,17 +129,34 @@ fun DmsApplicationCard(
 private fun AppliedTitleText(
     modifier: Modifier = Modifier,
     appliedTitle: String,
+    badgeStatus: ApplicationBadgeStatus? = null,
 ) {
+    val backgroundColor = when (badgeStatus) {
+        ApplicationBadgeStatus.APPROVED,
+        null,
+        -> DmsTheme.colors.primary
+
+        ApplicationBadgeStatus.REJECTED -> DmsTheme.colors.error
+        ApplicationBadgeStatus.PENDING -> DmsTheme.colors.surfaceVariant
+    }
+    val textColor = when (badgeStatus) {
+        ApplicationBadgeStatus.APPROVED,
+        null,
+        -> DmsTheme.colors.onPrimaryContainer
+
+        ApplicationBadgeStatus.REJECTED -> DmsTheme.colors.onErrorContainer
+        ApplicationBadgeStatus.PENDING -> DmsTheme.colors.inverseSurface
+    }
+
     DmsText(
         modifier = modifier
             .background(
-                color = DmsTheme.colors.primary,
+                color = backgroundColor,
                 shape = RoundedCornerShape(6.dp),
             )
             .padding(horizontal = 22.dp, vertical = 8.dp),
         text = appliedTitle,
         style = DmsTypography.labelB,
-        color = DmsTheme.colors.onPrimaryContainer,
+        color = textColor,
     )
 }
-

--- a/core/network/src/commonMain/kotlin/team/aliens/dms/kmp/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/team/aliens/dms/kmp/core/network/di/NetworkModule.kt
@@ -17,6 +17,8 @@ import io.ktor.client.request.HttpRequestPipeline
 import io.ktor.client.request.accept
 import io.ktor.client.request.header
 import io.ktor.client.request.put
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -29,6 +31,9 @@ import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.modules.SerializersModule
 import org.koin.dsl.module
 import team.aliens.dms.kmp.core.common.exception.UnknownException
@@ -89,7 +94,9 @@ val networkModule = module {
                 validateResponse { response ->
                     if (!response.status.isSuccess()) {
                         when (response.status) {
-                            HttpStatusCode.BadRequest -> throw BadRequestException()
+                            HttpStatusCode.BadRequest -> throw BadRequestException(
+                                errorCode = response.errorCode(),
+                            )
                             HttpStatusCode.Unauthorized -> throw UnAuthorizedException()
                             HttpStatusCode.Forbidden -> throw ForbiddenException()
                             HttpStatusCode.UnprocessableEntity -> throw UnprocessableEntityException()
@@ -205,3 +212,10 @@ val networkModule = module {
 
     includes(ignoreRequestModule)
 }
+
+private suspend fun HttpResponse.errorCode(): String? = runCatching {
+    Json.parseToJsonElement(bodyAsText())
+        .jsonObject["code"]
+        ?.jsonPrimitive
+        ?.contentOrNull
+}.getOrNull()

--- a/core/network/src/commonMain/kotlin/team/aliens/dms/kmp/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/team/aliens/dms/kmp/core/network/di/NetworkModule.kt
@@ -27,6 +27,7 @@ import io.ktor.http.contentType
 import io.ktor.http.encodedPath
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
@@ -213,9 +214,14 @@ val networkModule = module {
     includes(ignoreRequestModule)
 }
 
-private suspend fun HttpResponse.errorCode(): String? = runCatching {
-    Json.parseToJsonElement(bodyAsText())
-        .jsonObject["code"]
-        ?.jsonPrimitive
-        ?.contentOrNull
-}.getOrNull()
+private suspend fun HttpResponse.errorCode(): String? =
+    try {
+        Json.parseToJsonElement(bodyAsText())
+            .jsonObject["code"]
+            ?.jsonPrimitive
+            ?.contentOrNull
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        null
+    }

--- a/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/navigation/ApplicationNavigation.kt
+++ b/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/navigation/ApplicationNavigation.kt
@@ -11,6 +11,8 @@ import team.aliens.dms.kmp.feature.application.ui.Application
 data object ApplicationRoute
 
 fun NavGraphBuilder.application(
+    shouldRefreshLateStudyStatus: Boolean,
+    onLateStudyStatusRefreshed: () -> Unit,
     onNavigateRemainApplication: () -> Unit,
     onNavigateOutingApplication: () -> Unit,
     onNavigateLateStudyApplication: () -> Unit,
@@ -20,6 +22,8 @@ fun NavGraphBuilder.application(
 ) {
     composable<ApplicationRoute> {
         Application(
+            shouldRefreshLateStudyStatus = shouldRefreshLateStudyStatus,
+            onLateStudyStatusRefreshed = onLateStudyStatusRefreshed,
             onNavigateRemainApplication = onNavigateRemainApplication,
             onNavigateOutingApplication = onNavigateOutingApplication,
             onNavigateLateStudyApplication = onNavigateLateStudyApplication,

--- a/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/ui/ApplicationScreen.kt
+++ b/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/ui/ApplicationScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -28,6 +29,8 @@ import team.aliens.dms.kmp.feature.application.viewmodel.ApplicationViewModel
 @Composable
 internal fun Application(
     viewModel: ApplicationViewModel = koinViewModel(),
+    shouldRefreshLateStudyStatus: Boolean,
+    onLateStudyStatusRefreshed: () -> Unit,
     onNavigateRemainApplication: () -> Unit,
     onNavigateOutingApplication: () -> Unit,
     onNavigateLateStudyApplication: () -> Unit,
@@ -36,6 +39,13 @@ internal fun Application(
     onShowSnackBar: (DmsSnackBarType, String) -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(shouldRefreshLateStudyStatus) {
+        if (shouldRefreshLateStudyStatus) {
+            viewModel.refreshLateStudyStatus()
+            onLateStudyStatusRefreshed()
+        }
+    }
 
     ApplicationScreen(
         state = state,
@@ -109,7 +119,7 @@ private fun ApplicationScreen(
                 if (page == 0) {
                     ApplicationContent(
                         appliedTitle = state.appliedTitle,
-                        lateStudyAppliedTitle = state.lateStudyAppliedTitle,
+        lateStudyApplicationStatus = state.lateStudyApplicationStatus,
                         onNavigateOutingApplication = onNavigateOutingApplication,
                         onNavigateRemainApplication = onNavigateRemainApplication,
                         onNavigateLateStudyApplication = onNavigateLateStudyApplication,

--- a/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/ui/component/ApplicationContent.kt
+++ b/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/ui/component/ApplicationContent.kt
@@ -13,12 +13,13 @@ import dmskmp.core.design_system.generated.resources.img_latestudy
 import dmskmp.core.design_system.generated.resources.img_outing
 import dmskmp.core.design_system.generated.resources.img_volunteer
 import team.aliens.dms.kmp.core.designsystem.card.DmsApplicationCard
+import team.aliens.dms.kmp.feature.application.viewmodel.LateStudyApplicationStatus
 
 @Composable
 internal fun ApplicationContent(
     modifier: Modifier = Modifier,
     appliedTitle: String?,
-    lateStudyAppliedTitle: String?,
+    lateStudyApplicationStatus: LateStudyApplicationStatus?,
     onNavigateRemainApplication: () -> Unit,
     onNavigateOutingApplication: () -> Unit,
     onNavigateLateStudyApplication: () -> Unit,
@@ -50,7 +51,8 @@ internal fun ApplicationContent(
             title = "새벽 자습 신청하기",
             iconRes = Res.drawable.img_latestudy,
             onClick = onNavigateLateStudyApplication,
-            appliedTitle = lateStudyAppliedTitle,
+            appliedTitle = lateStudyApplicationStatus?.title,
+            appliedBadgeStatus = lateStudyApplicationStatus?.badgeStatus,
         )
 
         DmsApplicationCard(

--- a/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/viewmodel/ApplicationViewModel.kt
+++ b/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/viewmodel/ApplicationViewModel.kt
@@ -5,6 +5,7 @@ import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
 import team.aliens.dms.kmp.core.common.base.BaseViewModel
 import team.aliens.dms.kmp.core.data.latestudy.repository.LateStudyRepository
 import team.aliens.dms.kmp.core.designsystem.card.ApplicationBadgeStatus
@@ -99,14 +100,24 @@ private fun StudyApplicationStatusModel.toApplicationStatus(): LateStudyApplicat
 private fun StudyApplicationStatusModel.buildRangeText(
     suffix: String,
 ): String? {
+    val startDate = startDate
+    val endDate = endDate
+
     return when {
         !startDate.isNullOrBlank() && !endDate.isNullOrBlank() -> {
-            if (startDate == endDate) "$startDate $suffix"
-            else "$startDate ~ $endDate $suffix"
+            val formattedStartDate = startDate.toMonthDayOrNull() ?: return null
+            val formattedEndDate = endDate.toMonthDayOrNull() ?: return null
+
+            if (startDate == endDate) "$formattedStartDate $suffix"
+            else "$formattedStartDate ~ $formattedEndDate $suffix"
         }
 
-        !startDate.isNullOrBlank() -> "$startDate $suffix"
-        !endDate.isNullOrBlank() -> "$endDate $suffix"
+        !startDate.isNullOrBlank() -> startDate.toMonthDayOrNull()?.let { "$it $suffix" }
+        !endDate.isNullOrBlank() -> endDate.toMonthDayOrNull()?.let { "$it $suffix" }
         else -> null
     }
 }
+
+private fun String.toMonthDayOrNull(): String? = runCatching {
+    LocalDate.parse(this).let { "${it.monthNumber}.${it.dayOfMonth}" }
+}.getOrNull()

--- a/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/viewmodel/ApplicationViewModel.kt
+++ b/feature/application/src/commonMain/kotlin/team/aliens/dms/kmp/feature/application/viewmodel/ApplicationViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
 import team.aliens.dms.kmp.core.common.base.BaseViewModel
 import team.aliens.dms.kmp.core.data.latestudy.repository.LateStudyRepository
+import team.aliens.dms.kmp.core.designsystem.card.ApplicationBadgeStatus
 import team.aliens.dms.kmp.core.domain.usecase.remains.GetRemainUseCase
 import team.aliens.dms.kmp.core.domain.usecase.votes.GetAllVotesUseCase
 import team.aliens.dms.kmp.core.model.latestudy.StudyApplicationStatusModel
@@ -21,7 +22,7 @@ internal class ApplicationViewModel(
     init {
         getAllVotes()
         getRemain()
-        getLateStudyStatus()
+        refreshLateStudyStatus()
     }
 
     private fun getAllVotes() {
@@ -46,14 +47,14 @@ internal class ApplicationViewModel(
         }
     }
 
-    private fun getLateStudyStatus() {
+    fun refreshLateStudyStatus() {
         viewModelScope.launch(Dispatchers.IO) {
             runCatching {
                 lateStudyRepository.fetchMyStudyApplicationStatus()
             }.onSuccess { status ->
                 setState {
                     state.value.copy(
-                        lateStudyAppliedTitle = status.toAppliedTitle(),
+                        lateStudyApplicationStatus = status.toApplicationStatus(),
                     )
                 }
             }.onFailure {
@@ -65,19 +66,34 @@ internal class ApplicationViewModel(
 
 data class ApplicationState(
     val appliedTitle: String? = null,
-    val lateStudyAppliedTitle: String? = null,
+    val lateStudyApplicationStatus: LateStudyApplicationStatus? = null,
     val votes: List<VoteModel> = emptyList(),
 )
 
 sealed interface ApplicationSideEffect
 
-private fun StudyApplicationStatusModel.toAppliedTitle(): String? {
-    return when (status) {
-        "SECOND_APPROVED" -> buildRangeText("승인됨")
-        "PENDING" -> "신청 중"
-        "REJECTED" -> buildRangeText("거절됨") ?: "거절됨"
-        else -> null
-    }
+data class LateStudyApplicationStatus(
+    val title: String,
+    val badgeStatus: ApplicationBadgeStatus,
+)
+
+private fun StudyApplicationStatusModel.toApplicationStatus(): LateStudyApplicationStatus? = when (status) {
+    "APPROVED", "SECOND_APPROVED" -> LateStudyApplicationStatus(
+        title = buildRangeText("승인됨") ?: "승인됨",
+        badgeStatus = ApplicationBadgeStatus.APPROVED,
+    )
+
+    "PENDING" -> LateStudyApplicationStatus(
+        title = "신청 중",
+        badgeStatus = ApplicationBadgeStatus.PENDING,
+    )
+
+    "REJECTED" -> LateStudyApplicationStatus(
+        title = buildRangeText("거절됨") ?: "거절됨",
+        badgeStatus = ApplicationBadgeStatus.REJECTED,
+    )
+
+    else -> null
 }
 
 private fun StudyApplicationStatusModel.buildRangeText(

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyCalendarSection.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyCalendarSection.kt
@@ -28,6 +28,7 @@ import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
 @Composable
 fun LateStudyCalendarSection(
     currentMonth: CalendarYearMonth,
+    minimumDate: LocalDate,
     startDate: LocalDate?,
     endDate: LocalDate?,
     onPrevMonthClick: () -> Unit,
@@ -93,6 +94,7 @@ fun LateStudyCalendarSection(
 
         CalendarGrid(
             currentMonth = currentMonth,
+            minimumDate = minimumDate,
             startDate = startDate,
             endDate = endDate,
             onDateClick = onDateClick,
@@ -137,6 +139,7 @@ private fun CalendarDayHeader() {
 @Composable
 private fun CalendarGrid(
     currentMonth: CalendarYearMonth,
+    minimumDate: LocalDate,
     startDate: LocalDate?,
     endDate: LocalDate?,
     onDateClick: (LocalDate) -> Unit,
@@ -159,7 +162,10 @@ private fun CalendarGrid(
                 val isSingleSelected = startDate != null &&
                         endDate == null &&
                         item.date == startDate
-                val isSelectable = item.isCurrentMonth && isSelectableDate(item.date)
+                val isSelectable = item.isCurrentMonth && isSelectableDate(
+                    date = item.date,
+                    minimumDate = minimumDate,
+                )
 
                 CalendarDateCell(
                     date = item.date,
@@ -377,14 +383,15 @@ private fun buildCalendarDates(
     return result
 }
 
-private fun isSelectableDate(date: LocalDate): Boolean {
-    return when (date.dayOfWeek) {
-        DayOfWeek.FRIDAY,
-        DayOfWeek.SATURDAY,
-        DayOfWeek.SUNDAY -> false
-        else -> true
-    }
-}
+private fun isSelectableDate(
+    date: LocalDate,
+    minimumDate: LocalDate,
+): Boolean = date >= minimumDate && date.dayOfWeek in setOf(
+    DayOfWeek.MONDAY,
+    DayOfWeek.TUESDAY,
+    DayOfWeek.WEDNESDAY,
+    DayOfWeek.THURSDAY,
+)
 
 data class CalendarYearMonth(
     val year: Int,

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/di/LateStudyModule.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/di/LateStudyModule.kt
@@ -7,10 +7,12 @@ import team.aliens.dms.kmp.feature.latestudy.ui.LateStudyScreen
 @Composable
 fun LateStudyRoute(
     onBack: () -> Unit,
+    onSubmitted: () -> Unit = {},
     onShowSnackBar: (DmsSnackBarType, String) -> Unit,
 ) {
     LateStudyScreen(
         onBack = onBack,
+        onSubmitted = onSubmitted,
         onShowSnackBar = onShowSnackBar,
     )
 }

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/navigation/LateStudyRoute.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/navigation/LateStudyRoute.kt
@@ -10,15 +10,19 @@ import team.aliens.dms.kmp.feature.latestudy.ui.LateStudyScreen
 @Serializable
 data object LateStudyRoute
 
+const val LATE_STUDY_STATUS_REFRESH_KEY = "late_study_status_refresh"
+
 fun NavController.navigateToLateStudy() = navigate(LateStudyRoute)
 
 fun NavGraphBuilder.lateStudy(
     onNavigateBack: () -> Unit,
+    onSubmitted: () -> Unit,
     onShowSnackBar: (DmsSnackBarType, String) -> Unit,
 ) {
     composable<LateStudyRoute> {
         LateStudyScreen(
             onBack = onNavigateBack,
+            onSubmitted = onSubmitted,
             onShowSnackBar = onShowSnackBar,
         )
     }

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
@@ -57,6 +57,7 @@ import team.aliens.dms.kmp.feature.latestudy.viewmodel.LateStudyViewModel
 @Composable
 fun LateStudyScreen(
     onBack: () -> Unit,
+    onSubmitted: () -> Unit,
     onShowSnackBar: (DmsSnackBarType, String) -> Unit,
     viewModel: LateStudyViewModel = koinViewModel(),
 ) {
@@ -150,6 +151,7 @@ fun LateStudyScreen(
 
         LateStudyCalendarSection(
             currentMonth = currentMonth,
+            minimumDate = today,
             startDate = startDate,
             endDate = endDate,
             onPrevMonthClick = { currentMonth = currentMonth.minusMonths(1) },
@@ -189,6 +191,7 @@ fun LateStudyScreen(
                     endDate = (endDate ?: selectedStartDate).toString(),
                     onSuccess = {
                         onShowSnackBar(DmsSnackBarType.SUCCESS, "새벽 자습 신청이 완료되었습니다")
+                        onSubmitted()
                         onBack()
                     },
                     onFailure = { message ->

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/viewmodel/LateStudyViewModel.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/viewmodel/LateStudyViewModel.kt
@@ -7,7 +7,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import team.aliens.dms.kmp.core.common.exception.network.BadRequestException
 import team.aliens.dms.kmp.core.common.exception.network.ConflictException
+import team.aliens.dms.kmp.core.common.exception.network.ForbiddenException
+import team.aliens.dms.kmp.core.common.exception.network.InternalServerErrorException
+import team.aliens.dms.kmp.core.common.exception.network.NotFoundException
+import team.aliens.dms.kmp.core.common.exception.network.TooManyRequestsException
+import team.aliens.dms.kmp.core.common.exception.network.UnAuthorizedException
 import team.aliens.dms.kmp.core.data.latestudy.repository.LateStudyRepository
 import team.aliens.dms.kmp.core.model.latestudy.StudyTypeModel
 import team.aliens.dms.kmp.core.model.latestudy.TeacherModel
@@ -111,15 +117,29 @@ class LateStudyViewModel(
                     ),
                 )
                 onSuccess()
-            } catch (e: ConflictException) {
-                onFailure("이미 새벽 자습을 신청했습니다.")
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                onFailure("새벽 자습 신청에 실패했습니다.")
+                onFailure(e.toLateStudyErrorMessage())
             } finally {
                 isSubmitting = false
             }
         }
     }
+}
+
+private fun Exception.toLateStudyErrorMessage(): String = when (this) {
+    is BadRequestException -> when (errorCode) {
+        "DAYBREAK-400-1" -> "시작 날짜는 종료 날짜보다 늦을 수 없습니다."
+        "DAYBREAK-400-2" -> "과거 날짜는 신청할 수 없습니다."
+        "DAYBREAK-400-3" -> "새벽 자습은 월요일부터 목요일까지만 신청할 수 있습니다."
+        else -> "신청 정보를 다시 확인해주세요."
+    }
+    is UnAuthorizedException -> "로그인이 만료되었습니다. 다시 로그인해주세요."
+    is ForbiddenException -> "새벽 자습 신청 권한이 없습니다."
+    is NotFoundException -> "담당 선생님 또는 새벽 자습 유형을 찾을 수 없습니다."
+    is ConflictException -> "이미 새벽 자습을 신청했거나 승인된 신청이 있습니다."
+    is TooManyRequestsException -> "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+    is InternalServerErrorException -> "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+    else -> "새벽 자습 신청에 실패했습니다."
 }

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/viewmodel/LateStudyViewModel.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/viewmodel/LateStudyViewModel.kt
@@ -7,6 +7,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
 import team.aliens.dms.kmp.core.common.exception.network.BadRequestException
 import team.aliens.dms.kmp.core.common.exception.network.ConflictException
 import team.aliens.dms.kmp.core.common.exception.network.ForbiddenException
@@ -18,11 +24,13 @@ import team.aliens.dms.kmp.core.data.latestudy.repository.LateStudyRepository
 import team.aliens.dms.kmp.core.model.latestudy.StudyTypeModel
 import team.aliens.dms.kmp.core.model.latestudy.TeacherModel
 import team.aliens.dms.kmp.core.network.latestudy.model.request.SubmitLateStudyRequest
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class LateStudyViewModel(
     private val lateStudyRepository: LateStudyRepository,
 ) : ViewModel() {
-
     var studyTypes by mutableStateOf<List<StudyTypeModel>>(emptyList())
         private set
 
@@ -75,9 +83,10 @@ class LateStudyViewModel(
 
     fun updateTeacherKeyword(keyword: String) {
         teacherKeyword = keyword
-        selectedTeacherId = teachers
-            .firstOrNull { it.name == keyword }
-            ?.id
+        selectedTeacherId =
+            teachers
+                .firstOrNull { it.name == keyword }
+                ?.id
     }
 
     fun selectTeacher(teacher: TeacherModel) {
@@ -100,6 +109,23 @@ class LateStudyViewModel(
 
         if (teacherId == null || typeId == null || reason.isBlank()) {
             onFailure("모두 선택해주세요")
+            return
+        }
+
+        val selectedStartDate = startDate.toLocalDateOrNull()
+        val selectedEndDate = endDate.toLocalDateOrNull()
+        if (selectedStartDate == null || selectedEndDate == null) {
+            onFailure("신청 정보를 다시 확인해주세요.")
+            return
+        }
+
+        val validationMessage =
+            validateLateStudyPeriod(
+                startDate = selectedStartDate,
+                endDate = selectedEndDate,
+            )
+        if (validationMessage != null) {
+            onFailure(validationMessage)
             return
         }
 
@@ -128,18 +154,58 @@ class LateStudyViewModel(
     }
 }
 
-private fun Exception.toLateStudyErrorMessage(): String = when (this) {
-    is BadRequestException -> when (errorCode) {
-        "DAYBREAK-400-1" -> "시작 날짜는 종료 날짜보다 늦을 수 없습니다."
-        "DAYBREAK-400-2" -> "과거 날짜는 신청할 수 없습니다."
-        "DAYBREAK-400-3" -> "새벽 자습은 월요일부터 목요일까지만 신청할 수 있습니다."
-        else -> "신청 정보를 다시 확인해주세요."
+private fun Exception.toLateStudyErrorMessage(): String =
+    when (this) {
+        is BadRequestException ->
+            when (errorCode) {
+                "DAYBREAK-400-1" -> "시작 날짜는 종료 날짜보다 늦을 수 없습니다."
+                "DAYBREAK-400-2" -> "과거 날짜는 신청할 수 없습니다."
+                "DAYBREAK-400-3" -> "새벽 자습은 월요일부터 목요일까지만 신청할 수 있습니다."
+                else -> "신청 정보를 다시 확인해주세요."
+            }
+
+        is UnAuthorizedException -> "로그인이 만료되었습니다. 다시 로그인해주세요."
+        is ForbiddenException -> "새벽 자습 신청 권한이 없습니다."
+        is NotFoundException -> "담당 선생님 또는 새벽 자습 유형을 찾을 수 없습니다."
+        is ConflictException -> "이미 새벽 자습을 신청했거나 승인된 신청이 있습니다."
+        is TooManyRequestsException -> "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+        is InternalServerErrorException -> "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+        else -> "새벽 자습 신청에 실패했습니다."
     }
-    is UnAuthorizedException -> "로그인이 만료되었습니다. 다시 로그인해주세요."
-    is ForbiddenException -> "새벽 자습 신청 권한이 없습니다."
-    is NotFoundException -> "담당 선생님 또는 새벽 자습 유형을 찾을 수 없습니다."
-    is ConflictException -> "이미 새벽 자습을 신청했거나 승인된 신청이 있습니다."
-    is TooManyRequestsException -> "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
-    is InternalServerErrorException -> "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
-    else -> "새벽 자습 신청에 실패했습니다."
+
+@OptIn(ExperimentalTime::class)
+private fun validateLateStudyPeriod(
+    startDate: LocalDate,
+    endDate: LocalDate,
+): String? {
+    if (startDate > endDate) return "시작 날짜는 종료 날짜보다 늦을 수 없습니다."
+
+    val today =
+        Clock.System.now()
+            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .date
+    if (startDate < today || endDate < today) return "과거 날짜는 신청할 수 없습니다."
+
+    var date = startDate
+    while (date <= endDate) {
+        if (date.dayOfWeek !in LATE_STUDY_ALLOWED_DAYS) {
+            return "새벽 자습은 월요일부터 목요일까지만 신청할 수 있습니다."
+        }
+        date = date.plus(1, DateTimeUnit.DAY)
+    }
+
+    return null
 }
+
+private fun String.toLocalDateOrNull(): LocalDate? =
+    runCatching {
+        LocalDate.parse(this)
+    }.getOrNull()
+
+private val LATE_STUDY_ALLOWED_DAYS =
+    setOf(
+        DayOfWeek.MONDAY,
+        DayOfWeek.TUESDAY,
+        DayOfWeek.WEDNESDAY,
+        DayOfWeek.THURSDAY,
+    )


### PR DESCRIPTION
## 개요
> 새벽 자습 신청 기능을 전체적으로 개편하였습니다.

Android|iOS|Desktop
--|--|--

## 작업사항

- 과거 날짜와 금·토·일은 달력에서 선택하지 못하도록 처리
- 신청 성공 후 목록 화면으로 돌아오면 상태를 다시 조회하도록 수정
- 상태 배지 색상 적용: 승인 파랑 / 거절 빨강 / 신청 중 회색
- 승인·거절 날짜 형식을 4.9 ~ 4.10 승인됨처럼 변경

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 심야 자습 신청 결과에 승인·대기·거절 상태 배지가 표시됩니다.
  * 신청 완료 후 신청 현황이 자동으로 갱신됩니다.
  * 오늘 이전 날짜는 심야 자습 신청일로 선택할 수 없습니다.
  * 월요일부터 목요일까지만 신청 날짜로 선택할 수 있습니다.

* **버그 수정**
  * 네트워크 오류 유형에 따라 더 구체적인 안내 메시지를 제공합니다.
  * 잘못된 날짜 정보로 인한 상태 표시 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->