### PR TITLE
[bug #191] 새벽 자습 신청 디자인 수정

### DIFF
--- a/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/button/DmsButton.kt
+++ b/core/design-system/src/commonMain/kotlin/team/aliens/dms/kmp/core/designsystem/button/DmsButton.kt
@@ -56,134 +56,173 @@ data class ButtonTheme(
 )
 
 @Composable
-private fun ButtonColor.containedColors() = when (this) {
-    ButtonColor.Primary -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.surface,
-            backgroundColor = DmsTheme.colors.onPrimaryContainer,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.surface,
-            backgroundColor = DmsTheme.colors.inversePrimary,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.surfaceVariant,
-            backgroundColor = DmsTheme.colors.onPrimary,
-        ),
-    )
+private fun ButtonColor.containedColors() =
+    when (this) {
+        ButtonColor.Primary ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = Color.White,
+                        backgroundColor = DmsTheme.colors.onPrimaryContainer,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = Color.White,
+                        backgroundColor = DmsTheme.colors.inversePrimary,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = Color.White,
+                        backgroundColor = DmsTheme.colors.onPrimary,
+                    ),
+            )
 
-    ButtonColor.Gray -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.surfaceTint,
-            backgroundColor = DmsTheme.colors.inverseOnSurface,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.surfaceTint,
-            backgroundColor = DmsTheme.colors.surfaceBright,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.surfaceTint,
-            backgroundColor = DmsTheme.colors.surfaceVariant,
-        ),
-    )
+        ButtonColor.Gray ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.surfaceTint,
+                        backgroundColor = DmsTheme.colors.inverseOnSurface,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.surfaceTint,
+                        backgroundColor = DmsTheme.colors.surfaceBright,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.surfaceTint,
+                        backgroundColor = DmsTheme.colors.surfaceVariant,
+                    ),
+            )
 
-    ButtonColor.Error -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.surface,
-            backgroundColor = DmsTheme.colors.onErrorContainer,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.surface,
-            backgroundColor = DmsTheme.colors.onErrorContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.inverseSurface,
-            backgroundColor = DmsTheme.colors.outlineVariant,
-        ),
-    )
-}
-
-@Composable
-private fun ButtonColor.textColors() = when (this) {
-    ButtonColor.Primary -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.inverseSurface,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.onSecondaryContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.primaryContainer,
-        ),
-    )
-
-    ButtonColor.Gray -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.inverseSurface,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.tertiaryContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.onSurfaceVariant,
-        ),
-    )
-
-    ButtonColor.Error -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.inversePrimary,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.primaryContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.onPrimary,
-        ),
-    )
-
-    else -> throw IllegalArgumentException("Unhandled ButtonColor: $this")
-}
+        ButtonColor.Error ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.surface,
+                        backgroundColor = DmsTheme.colors.onErrorContainer,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.surface,
+                        backgroundColor = DmsTheme.colors.onErrorContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.inverseSurface,
+                        backgroundColor = DmsTheme.colors.outlineVariant,
+                    ),
+            )
+    }
 
 @Composable
-private fun ButtonColor.underlineColors() = when (this) {
-    ButtonColor.Primary -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.secondary,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.secondaryContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.primaryContainer,
-        ),
-    )
+private fun ButtonColor.textColors() =
+    when (this) {
+        ButtonColor.Primary ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.inverseSurface,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.onSecondaryContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.primaryContainer,
+                    ),
+            )
 
-    ButtonColor.Gray -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.inverseSurface,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.tertiaryContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.onSurfaceVariant,
-        ),
-    )
+        ButtonColor.Gray ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.inverseSurface,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.tertiaryContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.onSurfaceVariant,
+                    ),
+            )
 
-    ButtonColor.Error -> ButtonState(
-        enabled = ButtonTheme(
-            textColor = DmsTheme.colors.outline,
-        ),
-        pressed = ButtonTheme(
-            textColor = DmsTheme.colors.errorContainer,
-        ),
-        disabled = ButtonTheme(
-            textColor = DmsTheme.colors.onError,
-        ),
-    )
+        ButtonColor.Error ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.inversePrimary,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.primaryContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.onPrimary,
+                    ),
+            )
 
-    else -> throw IllegalArgumentException("Unhandled ButtonColor: $this")
-}
+        else -> throw IllegalArgumentException("Unhandled ButtonColor: $this")
+    }
+
+@Composable
+private fun ButtonColor.underlineColors() =
+    when (this) {
+        ButtonColor.Primary ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.secondary,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.secondaryContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.primaryContainer,
+                    ),
+            )
+
+        ButtonColor.Gray ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.inverseSurface,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.tertiaryContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.onSurfaceVariant,
+                    ),
+            )
+
+        ButtonColor.Error ->
+            ButtonState(
+                enabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.outline,
+                    ),
+                pressed =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.errorContainer,
+                    ),
+                disabled =
+                    ButtonTheme(
+                        textColor = DmsTheme.colors.onError,
+                    ),
+            )
+
+        else -> throw IllegalArgumentException("Unhandled ButtonColor: $this")
+    }
 
 @Composable
 private fun BasicButton(
@@ -210,39 +249,42 @@ private fun BasicButton(
 
     val keyboardShow by keyboardAsState()
     val isKeyboardHideButton = keyboardShow && keyboardInteractionEnabled
-    val (shapeByKeyboardShow, pressDepth) = if (isKeyboardHideButton) {
-        RoundedCornerShape(0.dp) to MIN_PRESS_DEPTH
-    } else {
-        shape to DEFAULT_PRESS_DEPTH
-    }
-    val padding = if (isKeyboardHideButton) {
-        PaddingValues(
-            vertical = 0.dp,
-            horizontal = 0.dp,
-        )
-    } else {
-        PaddingValues(
-            vertical = 12.dp,
-            horizontal = 24.dp,
-        )
-    }
+    val (shapeByKeyboardShow, pressDepth) =
+        if (isKeyboardHideButton) {
+            RoundedCornerShape(0.dp) to MIN_PRESS_DEPTH
+        } else {
+            shape to DEFAULT_PRESS_DEPTH
+        }
+    val padding =
+        if (isKeyboardHideButton) {
+            PaddingValues(
+                vertical = 0.dp,
+                horizontal = 0.dp,
+            )
+        } else {
+            PaddingValues(
+                vertical = 12.dp,
+                horizontal = 24.dp,
+            )
+        }
 
     Box(
-        modifier = modifier
-            .modifyIf(keyboardInteractionEnabled) {
-                padding(padding)
-            }
-            .clip(shape = shapeByKeyboardShow)
-            .background(color = backgroundColor, shape = shapeByKeyboardShow)
-            .clickable(
-                pressDepth = pressDepth,
-                enabled = enabled,
-                onPressed = onPressed,
-                onClick = onClick,
-            )
-            .modifyIf(keyboardInteractionEnabled) {
-                imePadding()
-            },
+        modifier =
+            modifier
+                .modifyIf(keyboardInteractionEnabled) {
+                    padding(padding)
+                }
+                .clip(shape = shapeByKeyboardShow)
+                .background(color = backgroundColor, shape = shapeByKeyboardShow)
+                .clickable(
+                    pressDepth = pressDepth,
+                    enabled = enabled,
+                    onPressed = onPressed,
+                    onClick = onClick,
+                )
+                .modifyIf(keyboardInteractionEnabled) {
+                    imePadding()
+                },
         contentAlignment = Alignment.Center,
     ) {
         content()
@@ -264,38 +306,42 @@ fun DmsButton(
 ) {
     var pressed by remember { mutableStateOf(false) }
 
-    val buttonColors = when (buttonType) {
-        ButtonType.Contained -> buttonColor.containedColors()
-        ButtonType.Text -> buttonColor.textColors()
-        ButtonType.Underline -> buttonColor.underlineColors()
-    }
+    val buttonColors =
+        when (buttonType) {
+            ButtonType.Contained -> buttonColor.containedColors()
+            ButtonType.Text -> buttonColor.textColors()
+            ButtonType.Underline -> buttonColor.underlineColors()
+        }
 
     val backgroundColor by animateColorAsState(
-        targetValue = if (!enabled) {
-            buttonColors.disabled.backgroundColor ?: Color.Transparent
-        } else if (pressed) {
-            buttonColors.pressed.backgroundColor ?: Color.Transparent
-        } else {
-            buttonColors.enabled.backgroundColor ?: Color.Transparent
-        },
+        targetValue =
+            if (!enabled) {
+                buttonColors.disabled.backgroundColor ?: Color.Transparent
+            } else if (pressed) {
+                buttonColors.pressed.backgroundColor ?: Color.Transparent
+            } else {
+                buttonColors.enabled.backgroundColor ?: Color.Transparent
+            },
     )
     val borderColor by animateColorAsState(
-        targetValue = if (!enabled) {
-            buttonColors.disabled.borderColor ?: Color.Transparent
-        } else if (pressed) {
-            buttonColors.pressed.borderColor ?: Color.Transparent
-        } else {
-            buttonColors.enabled.borderColor ?: Color.Transparent
-        },
+        targetValue =
+            if (!enabled) {
+                buttonColors.disabled.borderColor ?: Color.Transparent
+            } else if (pressed) {
+                buttonColors.pressed.borderColor ?: Color.Transparent
+            } else {
+                buttonColors.enabled.borderColor ?: Color.Transparent
+            },
     )
     val contentColor by animateColorAsState(
-        targetValue = if (!enabled) {
-            buttonColors.disabled.textColor
-        } else if (pressed) {
-            buttonColors.pressed.textColor
-        } else {
-            buttonColors.enabled.textColor
-        },
+        targetValue =
+            if (!enabled) {
+                buttonColors.disabled.textColor
+            } else if (pressed) {
+                buttonColors.pressed.textColor
+            } else {
+                buttonColors.enabled.textColor
+            },
     )
     val innerPadding =
         if (buttonType == ButtonType.Text || buttonType == ButtonType.Underline) {
@@ -321,17 +367,19 @@ fun DmsButton(
         keyboardInteractionEnabled = keyboardInteractionEnabled,
     ) {
         val padding = contentPadding ?: innerPadding
-        val textStyle = if (buttonType == ButtonType.Underline || buttonType == ButtonType.Text) {
-            DmsTypography.labelM
-        } else {
-            DmsTypography.BodyB
-        }
+        val textStyle =
+            if (buttonType == ButtonType.Underline || buttonType == ButtonType.Text) {
+                DmsTypography.labelM
+            } else {
+                DmsTypography.BodyB
+            }
         val size = with(LocalDensity.current) { textStyle.fontSize.toDp() * 1.2f }
 
         Box(
-            modifier = Modifier
-                .padding(padding)
-                .height(size),
+            modifier =
+                Modifier
+                    .padding(padding)
+                    .height(size),
             contentAlignment = Alignment.Center,
         ) {
             if (isLoading) {

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyCalendarSection.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyCalendarSection.kt
@@ -40,33 +40,33 @@ fun LateStudyCalendarSection(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 2.dp),
+                .padding(start = 16.dp, end = 16.dp, top = 24.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Text(
                 text = "일정",
-                color = DmsTheme.colors.onBackground,
+                color = DmsTheme.colors.inverseOnSurface,
                 style = DmsTypography.BodyB,
             )
 
             Text(
                 text = "(새벽 자습은 금, 토, 일요일은 불가능합니다)",
                 color = DmsTheme.colors.inverseSurface,
-                style = DmsTypography.BodyM,
+                style = DmsTypography.labelM,
             )
         }
 
-        Spacer(modifier = Modifier.size(10.dp))
+        Spacer(modifier = Modifier.size(20.dp))
 
         Row(
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             IconButton(onClick = onPrevMonthClick) {
                 Text(
                     text = "<",
-                    color = DmsTheme.colors.onBackground,
+                    color = DmsTheme.colors.scrim,
                     style = DmsTypography.BodyM,
                 )
             }
@@ -75,8 +75,8 @@ fun LateStudyCalendarSection(
 
             Text(
                 text = "${currentMonth.year} ${currentMonth.monthNumber}월",
-                color = DmsTheme.colors.onBackground,
-                style = DmsTypography.BodyB,
+                color = DmsTheme.colors.tertiaryContainer,
+                style = DmsTypography.BodyM,
             )
 
             Spacer(modifier = Modifier.width(8.dp))
@@ -84,7 +84,7 @@ fun LateStudyCalendarSection(
             IconButton(onClick = onNextMonthClick) {
                 Text(
                     text = ">",
-                    color = DmsTheme.colors.onBackground,
+                    color = DmsTheme.colors.scrim,
                     style = DmsTypography.BodyM,
                 )
             }
@@ -100,7 +100,7 @@ fun LateStudyCalendarSection(
             onDateClick = onDateClick,
         )
 
-        Spacer(modifier = Modifier.size(4.dp))
+        Spacer(modifier = Modifier.size(24.dp))
     }
 }
 
@@ -116,10 +116,10 @@ private fun CalendarDayHeader() {
     ) {
         days.forEachIndexed { index, day ->
             val color = when (index) {
-                0 -> DmsTheme.colors.error
-                5 -> DmsTheme.colors.inverseSurface
-                6 -> DmsTheme.colors.primary
-                else -> DmsTheme.colors.onBackground
+                0 -> DmsTheme.colors.onError
+                5 -> DmsTheme.colors.onSurfaceVariant
+                6 -> DmsTheme.colors.onPrimary
+                else -> DmsTheme.colors.tertiaryContainer
             }
 
             Box(
@@ -245,7 +245,7 @@ private fun CalendarRangeBackground(
                 .height(30.dp)
                 .padding(start = 15.dp)
                 .background(
-                    color = DmsTheme.colors.primary.copy(alpha = 0.4f),
+                    color = DmsTheme.colors.primaryContainer,
                     shape = RoundedCornerShape(
                         topStart = 999.dp,
                         bottomStart = 999.dp,
@@ -259,7 +259,7 @@ private fun CalendarRangeBackground(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(30.dp)
-                .background(DmsTheme.colors.primary.copy(alpha = 0.4f)),
+                .background(DmsTheme.colors.primaryContainer),
         )
     }
 
@@ -270,7 +270,7 @@ private fun CalendarRangeBackground(
                 .height(30.dp)
                 .padding(end = 15.dp)
                 .background(
-                    color = DmsTheme.colors.primary.copy(alpha = 0.4f),
+                    color = DmsTheme.colors.primaryContainer,
                     shape = RoundedCornerShape(
                         topEnd = 999.dp,
                         bottomEnd = 999.dp,
@@ -286,7 +286,7 @@ private fun SelectedDateBackground() {
         modifier = Modifier
             .size(30.dp)
             .background(
-                color = DmsTheme.colors.primary,
+                color = DmsTheme.colors.onPrimaryContainer,
                 shape = CircleShape,
             ),
     )
@@ -324,14 +324,15 @@ private fun calendarDateTextColor(
     isInRange: Boolean,
 ): Color {
     return when {
-        isSelected || isInRange -> DmsTheme.colors.surface
-        !isCurrentMonth && date.dayOfWeek == DayOfWeek.SUNDAY -> DmsTheme.colors.error.copy(alpha = 0.45f)
-        !isCurrentMonth && date.dayOfWeek == DayOfWeek.SATURDAY -> DmsTheme.colors.primary.copy(alpha = 0.45f)
-        !isCurrentMonth -> DmsTheme.colors.onSurfaceVariant
-        date.dayOfWeek == DayOfWeek.SUNDAY -> DmsTheme.colors.error
-        date.dayOfWeek == DayOfWeek.SATURDAY -> DmsTheme.colors.primary
-        date.dayOfWeek == DayOfWeek.FRIDAY -> DmsTheme.colors.inverseSurface
-        else -> DmsTheme.colors.onBackground
+        isSelected -> Color.White
+        isInRange -> DmsTheme.colors.primary
+        !isCurrentMonth && date.dayOfWeek == DayOfWeek.SUNDAY -> DmsTheme.colors.onError
+        !isCurrentMonth && date.dayOfWeek == DayOfWeek.SATURDAY -> DmsTheme.colors.onPrimary
+        !isCurrentMonth -> DmsTheme.colors.inverseSurface
+        date.dayOfWeek == DayOfWeek.SUNDAY -> DmsTheme.colors.onError
+        date.dayOfWeek == DayOfWeek.SATURDAY -> DmsTheme.colors.onPrimary
+        date.dayOfWeek == DayOfWeek.FRIDAY -> DmsTheme.colors.onSurfaceVariant
+        else -> DmsTheme.colors.tertiaryContainer
     }
 }
 

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyReasonSection.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyReasonSection.kt
@@ -29,32 +29,32 @@ fun LateStudyReasonSection(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(start = 16.dp, end = 16.dp, top = 24.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
                 text = "사유",
-                color = DmsTheme.colors.onBackground,
+                color = DmsTheme.colors.inverseOnSurface,
                 style = DmsTypography.BodyB,
             )
 
             Text(
                 text = "${value.length}/$REASON_MAX_LENGTH",
                 color = DmsTheme.colors.inverseSurface,
-                modifier = Modifier.padding(top = 4.dp, end = 10.dp),
-                style = DmsTypography.BodyM,
+                modifier = Modifier,
+                style = DmsTypography.SLabelM,
             )
         }
 
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp)
+                .padding(start = 16.dp, end = 16.dp, top = 10.dp, bottom = 24.dp)
                 .background(
-                    color = DmsTheme.colors.background,
-                    shape = RoundedCornerShape(20.dp),
+                    color = DmsTheme.colors.onSurface,
+                    shape = RoundedCornerShape(32.dp),
                 )
-                .height(180.dp)
+                .height(220.dp)
                 .padding(horizontal = 16.dp, vertical = 16.dp),
         ) {
             BasicTextField(
@@ -66,7 +66,7 @@ fun LateStudyReasonSection(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 textStyle = DmsTypography.BodyM.copy(
-                    color = DmsTheme.colors.onBackground,
+                    color = DmsTheme.colors.tertiaryContainer,
                 ),
                 decorationBox = { innerTextField ->
                     Box {

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudySectionCard.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudySectionCard.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
 
@@ -22,10 +20,8 @@ fun LateStudySectionCard(
             .fillMaxWidth()
             .background(
                 color = DmsTheme.colors.surfaceTint,
-                shape = RoundedCornerShape(24.dp),
-            )
-            .clip(RoundedCornerShape(24.dp))
-            .padding(top = 20.dp, bottom = 14.dp),
+                shape = RoundedCornerShape(32.dp),
+            ),
         content = content,
     )
 }

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyTeacherSection.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyTeacherSection.kt
@@ -2,6 +2,7 @@ package team.aliens.dms.kmp.feature.latestudy.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,42 +21,45 @@ fun LateStudyTeacherSection(
     modifier: Modifier = Modifier,
 ) {
     LateStudySectionCard(modifier = modifier) {
-        Text(
-            text = "담당 선생님",
-            modifier = Modifier.padding(horizontal = 16.dp),
-            color = DmsTheme.colors.onBackground,
-            style = DmsTypography.BodyB,
-        )
+        Column(
+            modifier = Modifier.padding(16.dp),
+        ) {
+            Text(
+                text = "담당 선생님",
+                color = DmsTheme.colors.inverseOnSurface,
+                style = DmsTypography.BodyB,
+            )
 
-        BasicTextField(
-            value = value,
-            onValueChange = onValueChange,
-            textStyle = DmsTypography.BodyM.copy(
-                color = DmsTheme.colors.onBackground,
-            ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
-            decorationBox = { innerTextField ->
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(
-                            color = DmsTheme.colors.surfaceVariant,
-                            shape = RoundedCornerShape(20.dp),
-                        )
-                        .padding(horizontal = 20.dp, vertical = 16.dp),
-                ) {
-                    if (value.isEmpty()) {
-                        Text(
-                            text = "홍길동",
-                            color = DmsTheme.colors.inverseSurface,
-                            style = DmsTypography.BodyM,
-                        )
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                textStyle = DmsTypography.BodyM.copy(
+                    color = DmsTheme.colors.tertiaryContainer,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 10.dp),
+                decorationBox = { innerTextField ->
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                color = DmsTheme.colors.onSurface,
+                                shape = RoundedCornerShape(32.dp),
+                            )
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                    ) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = "홍길동",
+                                color = DmsTheme.colors.inverseSurface,
+                                style = DmsTypography.BodyM,
+                            )
+                        }
+                        innerTextField()
                     }
-                    innerTextField()
-                }
-            },
-        )
+                },
+            )
+        }
     }
 }

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyTypeItem.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyTypeItem.kt
@@ -11,12 +11,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.painterResource
+import team.aliens.dms.kmp.core.designsystem.foundation.DmsIcon
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
 
@@ -30,12 +34,12 @@ fun LateStudyTypeItem(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .height(56.dp)
+            .height(44.dp)
             .background(
                 color = if (selected) {
                     DmsTheme.colors.primary
                 } else {
-                    DmsTheme.colors.surfaceTint
+                    DmsTheme.colors.surface
                 },
             )
             .selectable(
@@ -50,9 +54,9 @@ fun LateStudyTypeItem(
         Text(
             text = text,
             color = if (selected) {
-                DmsTheme.colors.surface
+                DmsTheme.colors.inversePrimary
             } else {
-                DmsTheme.colors.onBackground
+                DmsTheme.colors.inverseOnSurface
             },
             style = DmsTypography.BodyM,
         )
@@ -63,17 +67,27 @@ fun LateStudyTypeItem(
                 .then(
                     if (selected) {
                         Modifier.background(
-                            color = DmsTheme.colors.surface,
+                            color = DmsTheme.colors.onPrimaryContainer,
                             shape = CircleShape,
                         )
                     } else {
                         Modifier.border(
                             width = 2.dp,
-                            color = DmsTheme.colors.onSurfaceVariant,
+                            color = DmsTheme.colors.inverseSurface,
                             shape = CircleShape,
                         )
                     },
                 ),
-        )
+            contentAlignment = Alignment.Center,
+        ) {
+            if (selected) {
+                Icon(
+                    painter = painterResource(DmsIcon.Check),
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
     }
 }

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -41,6 +42,8 @@ import org.koin.compose.viewmodel.koinViewModel
 import team.aliens.dms.kmp.core.designsystem.button.ButtonColor
 import team.aliens.dms.kmp.core.designsystem.button.ButtonType
 import team.aliens.dms.kmp.core.designsystem.button.DmsButton
+import team.aliens.dms.kmp.core.designsystem.button.DmsIconButton
+import team.aliens.dms.kmp.core.designsystem.foundation.DmsIcon
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
 import team.aliens.dms.kmp.core.designsystem.snackbar.DmsSnackBarType
@@ -84,124 +87,142 @@ fun LateStudyScreen(
             viewModel.reason.isNotBlank() &&
             !viewModel.isSubmitting
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(DmsTheme.colors.background)
-            .statusBarsPadding()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 14.dp, vertical = 16.dp),
+            .background(DmsTheme.colors.background),
     ) {
-        Text(
-            text = "< 뒤로가기",
-            color = DmsTheme.colors.onBackground,
-            style = DmsTypography.BodyM,
+        Column(
             modifier = Modifier
-                .padding(start = 4.dp)
-                .clickable { onBack() },
-        )
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        Text(
-            text = "새벽 자습 신청",
-            color = DmsTheme.colors.onBackground,
-            style = DmsTypography.TitleB,
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        TeacherSearchSection(
-            teacherKeyword = viewModel.teacherKeyword,
-            onKeywordChange = {
-                viewModel.updateTeacherKeyword(it)
-                isDropdownVisible = true
-            },
-            filteredTeachers = filteredTeachers,
-            isDropdownVisible = isDropdownVisible,
-            onTeacherClick = {
-                viewModel.selectTeacher(it)
-                isDropdownVisible = false
-                focusManager.clearFocus()
-            },
-        )
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        LateStudySectionCard {
-            Text(
-                text = "유형",
-                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
-                color = DmsTheme.colors.onBackground,
-                style = DmsTypography.BodyB,
+                .fillMaxSize()
+                .statusBarsPadding()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 10.dp),
+        ) {
+            DmsIconButton(
+                modifier = Modifier.padding(start = 2.dp),
+                resource = DmsIcon.Backward,
+                tint = DmsTheme.colors.scrim,
+                size = 48.dp,
+                contentPaddingValues = androidx.compose.foundation.layout.PaddingValues(12.dp),
+                contentDescription = "뒤로가기",
+                onClick = onBack,
             )
 
-            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "새벽 자습 신청",
+                color = DmsTheme.colors.tertiaryContainer,
+                style = DmsTypography.LBodyB,
+                modifier = Modifier.padding(start = 14.dp, top = 8.dp),
+            )
 
-            viewModel.studyTypes.forEach { type ->
-                LateStudyTypeItem(
-                    text = type.name,
-                    selected = viewModel.selectedTypeId == type.id,
-                    onClick = { viewModel.selectStudyType(type.id) },
+            Spacer(modifier = Modifier.height(16.dp))
+
+            TeacherSearchSection(
+                teacherKeyword = viewModel.teacherKeyword,
+                onKeywordChange = {
+                    viewModel.updateTeacherKeyword(it)
+                    isDropdownVisible = true
+                },
+                filteredTeachers = filteredTeachers,
+                isDropdownVisible = isDropdownVisible,
+                onTeacherClick = {
+                    viewModel.selectTeacher(it)
+                    isDropdownVisible = false
+                    focusManager.clearFocus()
+                },
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            LateStudySectionCard {
+                Text(
+                    text = "유형",
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp),
+                    color = DmsTheme.colors.inverseOnSurface,
+                    style = DmsTypography.BodyB,
                 )
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                viewModel.studyTypes.forEach { type ->
+                    LateStudyTypeItem(
+                        text = type.name,
+                        selected = viewModel.selectedTypeId == type.id,
+                        onClick = { viewModel.selectStudyType(type.id) },
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
             }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            LateStudyCalendarSection(
+                currentMonth = currentMonth,
+                minimumDate = today,
+                startDate = startDate,
+                endDate = endDate,
+                onPrevMonthClick = { currentMonth = currentMonth.minusMonths(1) },
+                onNextMonthClick = { currentMonth = currentMonth.plusMonths(1) },
+                onDateClick = { clickedDate ->
+                    when {
+                        startDate == null -> startDate = clickedDate
+                        endDate == null && clickedDate >= startDate!! -> endDate = clickedDate
+                        else -> {
+                            startDate = clickedDate
+                            endDate = null
+                        }
+                    }
+                },
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            LateStudyReasonSection(
+                value = viewModel.reason,
+                onValueChange = viewModel::updateReason,
+            )
+
+            Spacer(modifier = Modifier.height(152.dp))
         }
 
-        Spacer(modifier = Modifier.height(20.dp))
-
-        LateStudyCalendarSection(
-            currentMonth = currentMonth,
-            minimumDate = today,
-            startDate = startDate,
-            endDate = endDate,
-            onPrevMonthClick = { currentMonth = currentMonth.minusMonths(1) },
-            onNextMonthClick = { currentMonth = currentMonth.plusMonths(1) },
-            onDateClick = { clickedDate ->
-                when {
-                    startDate == null -> startDate = clickedDate
-                    endDate == null && clickedDate >= startDate!! -> endDate = clickedDate
-                    else -> {
-                        startDate = clickedDate
-                        endDate = null
-                    }
-                }
-            },
-        )
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        LateStudyReasonSection(
-            value = viewModel.reason,
-            onValueChange = viewModel::updateReason,
-        )
-
-        Spacer(modifier = Modifier.height(20.dp))
-
-        DmsButton(
-            modifier = Modifier.fillMaxWidth(),
-            text = "신청하기",
-            buttonType = ButtonType.Contained,
-            buttonColor = ButtonColor.Primary,
-            enabled = isEnabled,
-            onClick = {
-                val selectedStartDate = startDate ?: return@DmsButton
-
-                viewModel.submitLateStudy(
-                    startDate = selectedStartDate.toString(),
-                    endDate = (endDate ?: selectedStartDate).toString(),
-                    onSuccess = {
-                        onShowSnackBar(DmsSnackBarType.SUCCESS, "새벽 자습 신청이 완료되었습니다")
-                        onSubmitted()
-                        onBack()
-                    },
-                    onFailure = { message ->
-                        onShowSnackBar(DmsSnackBarType.ERROR, message)
-                    },
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(
+                    color = DmsTheme.colors.surfaceTint,
+                    shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
                 )
-            },
-        )
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp, vertical = 24.dp),
+        ) {
+            DmsButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = "신청하기",
+                buttonType = ButtonType.Contained,
+                buttonColor = ButtonColor.Primary,
+                enabled = isEnabled,
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 20.dp),
+                onClick = {
+                    val selectedStartDate = startDate ?: return@DmsButton
 
-        Spacer(modifier = Modifier.height(12.dp))
+                    viewModel.submitLateStudy(
+                        startDate = selectedStartDate.toString(),
+                        endDate = (endDate ?: selectedStartDate).toString(),
+                        onSuccess = {
+                            onShowSnackBar(DmsSnackBarType.SUCCESS, "새벽 자습 신청이 완료되었습니다")
+                            onSubmitted()
+                            onBack()
+                        },
+                        onFailure = { message ->
+                            onShowSnackBar(DmsSnackBarType.ERROR, message)
+                        },
+                    )
+                },
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## 개요
> 새벽 자습 신청 디자인을 전체적으로 수정했습니다.

Android|iOS|Desktop
--|--|--

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 지각 사유 신청 화면에 새 디자인이 적용되었습니다.
  * 신청 버튼이 화면 하단에 고정되어 콘텐츠를 확인하면서 쉽게 이용할 수 있습니다.
  * 뒤로가기 아이콘과 스크롤 가능한 콘텐츠 영역이 제공됩니다.
  * 지각 유형 선택 항목에 선택 상태를 나타내는 체크 표시가 추가되었습니다.

* **스타일 개선**
  * 버튼, 카드, 입력 영역, 달력의 색상·간격·모서리·텍스트 스타일이 전반적으로 개선되었습니다.
  * 선택 날짜와 날짜 범위가 더욱 명확하게 구분됩니다.
  * 입력 영역과 지각 유형 목록의 가독성과 시각적 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->