### PR TITLE
[bug #197] 새벽 자습 사유 입력 키보드 오류 수정

### DIFF
--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyReasonSection.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyReasonSection.kt
@@ -5,14 +5,19 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
@@ -25,6 +30,8 @@ fun LateStudyReasonSection(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val focusManager = LocalFocusManager.current
+
     LateStudySectionCard(modifier = modifier) {
         Row(
             modifier = Modifier
@@ -64,12 +71,16 @@ fun LateStudyReasonSection(
                         onValueChange(newValue)
                     }
                 },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
                 textStyle = DmsTypography.BodyM.copy(
                     color = DmsTheme.colors.tertiaryContainer,
                 ),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = { focusManager.clearFocus() },
+                ),
                 decorationBox = { innerTextField ->
-                    Box {
+                    Box(modifier = Modifier.fillMaxSize()) {
                         if (value.isEmpty()) {
                             Text(
                                 text = "새벽 자습을 신청한 이유를 작성해주세요",

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyReasonSection.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/component/LateStudyReasonSection.kt
@@ -11,13 +11,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTheme
 import team.aliens.dms.kmp.core.designsystem.foundation.DmsTypography
@@ -30,8 +26,6 @@ fun LateStudyReasonSection(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val focusManager = LocalFocusManager.current
-
     LateStudySectionCard(modifier = modifier) {
         Row(
             modifier = Modifier
@@ -74,10 +68,6 @@ fun LateStudyReasonSection(
                 modifier = Modifier.fillMaxSize(),
                 textStyle = DmsTypography.BodyM.copy(
                     color = DmsTheme.colors.tertiaryContainer,
-                ),
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                keyboardActions = KeyboardActions(
-                    onDone = { focusManager.clearFocus() },
                 ),
                 decorationBox = { innerTextField ->
                     Box(modifier = Modifier.fillMaxSize()) {

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
@@ -117,7 +117,10 @@ fun LateStudyScreen(
                 size = 48.dp,
                 contentPaddingValues = androidx.compose.foundation.layout.PaddingValues(12.dp),
                 contentDescription = "뒤로가기",
-                onClick = onBack,
+                onClick = {
+                    focusManager.clearFocus()
+                    onBack()
+                },
             )
 
             Text(
@@ -160,7 +163,10 @@ fun LateStudyScreen(
                     LateStudyTypeItem(
                         text = type.name,
                         selected = viewModel.selectedTypeId == type.id,
-                        onClick = { viewModel.selectStudyType(type.id) },
+                        onClick = {
+                            focusManager.clearFocus()
+                            viewModel.selectStudyType(type.id)
+                        },
                     )
                 }
 
@@ -174,9 +180,16 @@ fun LateStudyScreen(
                 minimumDate = today,
                 startDate = startDate,
                 endDate = endDate,
-                onPrevMonthClick = { currentMonth = currentMonth.minusMonths(1) },
-                onNextMonthClick = { currentMonth = currentMonth.plusMonths(1) },
+                onPrevMonthClick = {
+                    focusManager.clearFocus()
+                    currentMonth = currentMonth.minusMonths(1)
+                },
+                onNextMonthClick = {
+                    focusManager.clearFocus()
+                    currentMonth = currentMonth.plusMonths(1)
+                },
                 onDateClick = { clickedDate ->
+                    focusManager.clearFocus()
                     when {
                         startDate == null -> startDate = clickedDate
                         endDate == null && clickedDate >= startDate!! -> endDate = clickedDate
@@ -187,6 +200,7 @@ fun LateStudyScreen(
                     }
                 },
                 onPastDateClick = {
+                    focusManager.clearFocus()
                     onShowSnackBar(
                         DmsSnackBarType.ERROR,
                         "오늘 이후의 평일만 새벽 자습 날짜로 선택할 수 있습니다.",
@@ -223,6 +237,7 @@ fun LateStudyScreen(
                 enabled = isEnabled,
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 20.dp),
                 onClick = {
+                    focusManager.clearFocus()
                     val selectedStartDate = startDate ?: return@DmsButton
 
                     viewModel.submitLateStudy(

--- a/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
+++ b/feature/latestudy/src/commonMain/kotlin/team/aliens/dms/kmp/feature/latestudy/ui/LateStudyScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -30,6 +31,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -96,7 +98,10 @@ fun LateStudyScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(DmsTheme.colors.background),
+            .background(DmsTheme.colors.background)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = { focusManager.clearFocus() })
+            },
     ) {
         Column(
             modifier = Modifier


### PR DESCRIPTION
## 개요
> 새벽 자습 신청 사유 입력할 때 키보드 포커스가 안 되는 문제를 해결했습니다.

Android|iOS|Desktop
--|--|--

## 작업사항
- 

## 추가 로 할 말


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 지각 사유 입력란이 화면의 사용 가능한 공간을 충분히 활용하도록 개선되었습니다.
  * 키보드의 완료 버튼을 누르면 입력이 완료되고 포커스가 해제됩니다.
  * 화면의 빈 공간을 탭해도 키보드가 자동으로 내려갑니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->